### PR TITLE
fix: faulty implicit cast of `float` variable to `long`

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/server/src/main/java/Application.java
+++ b/server/src/main/java/Application.java
@@ -34,7 +34,7 @@ public class Application {
             } else {
                 // metric
             }
-            float startTime = System.currentTimeMillis();
+            long startTime = System.currentTimeMillis();
             world.process();
             time += System.currentTimeMillis() - startTime;
             if (runOnce) {


### PR DESCRIPTION
And also updated gradle wrapper 6.8 -> 6.8.3

Fixes [this security advisor issue](https://github.com/ao-libre/finisterra-v2/security/code-scanning/3?query=ref%3Arefs%2Fheads%2Fmain).